### PR TITLE
Add CSync

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,6 +65,7 @@ jobs:
                       BepInEx-BepInExPack-5.4.2100
                       Evaisa-LethalLib-1.1.1
                       WhiteSpike-Interactive_Terminal_API-1.3.0
+                      Sigurd-CSync-5.0.1
                   website: ${{ steps.get-properties.outputs.WEBSITE }}
                   files: |
                       ./src/ShipInventoryUpdated/bin/Release/ShipInventoryUpdated.dll

--- a/src/ShipInventoryUpdated/Configurations/ChuteConfig.cs
+++ b/src/ShipInventoryUpdated/Configurations/ChuteConfig.cs
@@ -14,7 +14,7 @@ internal class ChuteConfig : SyncedConfig2<ChuteConfig>
 	private const string SECTION = "Chute";
 
 	[SyncedEntryField] public readonly SyncedEntry<string> Blacklist;
-	[SyncedEntryField] public readonly SyncedEntry<float> StoreSpeed;
+	public readonly ConfigEntry<float> StoreSpeed;
 
 	public ChuteConfig(ConfigFile cfg) : base(GUID_)
 	{
@@ -24,7 +24,7 @@ internal class ChuteConfig : SyncedConfig2<ChuteConfig>
 			new ConfigDescription(Localization.Get("configuration.chute.blacklist.description"))
 		);
 
-		StoreSpeed = cfg.BindSyncedEntry(
+		StoreSpeed = cfg.Bind(
 			new ConfigDefinition(SECTION, "TimeToStore"),
 			0.5f,
 			new ConfigDescription(Localization.Get("configuration.chute.storeSpeed.description"))

--- a/src/ShipInventoryUpdated/Configurations/ChuteConfig.cs
+++ b/src/ShipInventoryUpdated/Configurations/ChuteConfig.cs
@@ -1,4 +1,6 @@
 using BepInEx.Configuration;
+using CSync.Extensions;
+using CSync.Lib;
 using ShipInventoryUpdated.Helpers;
 
 namespace ShipInventoryUpdated.Configurations;
@@ -11,21 +13,23 @@ internal class ChuteConfig : SyncedConfig2<ChuteConfig>
 	private const string GUID_ = MyPluginInfo.PLUGIN_GUID + "." + nameof(ChuteConfig);
 	private const string SECTION = "Chute";
 
-	public readonly ConfigEntry<string> Blacklist;
-	public readonly ConfigEntry<float> StoreSpeed;
+	[SyncedEntryField] public readonly SyncedEntry<string> Blacklist;
+	[SyncedEntryField] public readonly SyncedEntry<float> StoreSpeed;
 
 	public ChuteConfig(ConfigFile cfg) : base(GUID_)
 	{
-		Blacklist = cfg.Bind(
+		Blacklist = cfg.BindSyncedEntry(
 			new ConfigDefinition(SECTION, "ChuteBlacklist"),
 			"",
 			new ConfigDescription(Localization.Get("configuration.chute.blacklist.description"))
 		);
 
-		StoreSpeed = cfg.Bind(
+		StoreSpeed = cfg.BindSyncedEntry(
 			new ConfigDefinition(SECTION, "TimeToStore"),
 			0.5f,
 			new ConfigDescription(Localization.Get("configuration.chute.storeSpeed.description"))
 		);
+		
+		ConfigManager.Register(this); 
 	}
 }

--- a/src/ShipInventoryUpdated/Configurations/ChuteConfig.cs
+++ b/src/ShipInventoryUpdated/Configurations/ChuteConfig.cs
@@ -6,14 +6,15 @@ namespace ShipInventoryUpdated.Configurations;
 /// <summary>
 /// Class that holds the configurations related to the chute itself
 /// </summary>
-internal class ChuteConfig
+internal class ChuteConfig : SyncedConfig2<ChuteConfig>
 {
+	private const string GUID_ = MyPluginInfo.PLUGIN_GUID + "." + nameof(ChuteConfig);
 	private const string SECTION = "Chute";
 
 	public readonly ConfigEntry<string> Blacklist;
 	public readonly ConfigEntry<float> StoreSpeed;
 
-	public ChuteConfig(ConfigFile cfg)
+	public ChuteConfig(ConfigFile cfg) : base(GUID_)
 	{
 		Blacklist = cfg.Bind(
 			new ConfigDefinition(SECTION, "ChuteBlacklist"),

--- a/src/ShipInventoryUpdated/Configurations/InventoryConfig.cs
+++ b/src/ShipInventoryUpdated/Configurations/InventoryConfig.cs
@@ -1,4 +1,6 @@
 using BepInEx.Configuration;
+using CSync.Extensions;
+using CSync.Lib;
 using ShipInventoryUpdated.Helpers;
 
 namespace ShipInventoryUpdated.Configurations;
@@ -11,28 +13,30 @@ internal class InventoryConfig : SyncedConfig2<InventoryConfig>
 	private const string GUID_ = MyPluginInfo.PLUGIN_GUID + "." + nameof(InventoryConfig);
 	private const string SECTION = "Inventory";
 
-	public readonly ConfigEntry<int> MaxItemCount;
-	public readonly ConfigEntry<bool> ClearOnWipe;
-	public readonly ConfigEntry<float> RetrieveSpeed;
+	[SyncedEntryField] public readonly SyncedEntry<int> MaxItemCount;
+	[SyncedEntryField] public readonly SyncedEntry<bool> ClearOnWipe;
+	[SyncedEntryField] public readonly SyncedEntry<float> RetrieveSpeed;
 
 	public InventoryConfig(ConfigFile cfg) : base(GUID_)
 	{
-		MaxItemCount = cfg.Bind(
+		MaxItemCount = cfg.BindSyncedEntry(
 			new ConfigDefinition(SECTION, "MaxItemCount"),
 			5_000,
 			new ConfigDescription(Localization.Get("configuration.inventory.maxItemCount.description"))
 		);
 		
-		ClearOnWipe = cfg.Bind(
+		ClearOnWipe = cfg.BindSyncedEntry(
 			new ConfigDefinition(SECTION, "ClearOnWipe"),
 			true,
 			new ConfigDescription(Localization.Get("configuration.inventory.clearOnWipe.description"))
 		);
 
-		RetrieveSpeed = cfg.Bind(
+		RetrieveSpeed = cfg.BindSyncedEntry(
 			new ConfigDefinition(SECTION, "ChuteDelay"),
 			0.5f,
 			new ConfigDescription(Localization.Get("configuration.inventory.retrieveSpeed.description"))
 		);
+		
+		ConfigManager.Register(this); 
 	}
 }

--- a/src/ShipInventoryUpdated/Configurations/InventoryConfig.cs
+++ b/src/ShipInventoryUpdated/Configurations/InventoryConfig.cs
@@ -15,7 +15,7 @@ internal class InventoryConfig : SyncedConfig2<InventoryConfig>
 
 	[SyncedEntryField] public readonly SyncedEntry<int> MaxItemCount;
 	[SyncedEntryField] public readonly SyncedEntry<bool> ClearOnWipe;
-	[SyncedEntryField] public readonly SyncedEntry<float> RetrieveSpeed;
+	public readonly ConfigEntry<float> RetrieveSpeed;
 
 	public InventoryConfig(ConfigFile cfg) : base(GUID_)
 	{
@@ -31,7 +31,7 @@ internal class InventoryConfig : SyncedConfig2<InventoryConfig>
 			new ConfigDescription(Localization.Get("configuration.inventory.clearOnWipe.description"))
 		);
 
-		RetrieveSpeed = cfg.BindSyncedEntry(
+		RetrieveSpeed = cfg.Bind(
 			new ConfigDefinition(SECTION, "ChuteDelay"),
 			0.5f,
 			new ConfigDescription(Localization.Get("configuration.inventory.retrieveSpeed.description"))

--- a/src/ShipInventoryUpdated/Configurations/InventoryConfig.cs
+++ b/src/ShipInventoryUpdated/Configurations/InventoryConfig.cs
@@ -6,15 +6,16 @@ namespace ShipInventoryUpdated.Configurations;
 /// <summary>
 /// Class that holds the configurations related to the inventory itself
 /// </summary>
-internal class InventoryConfig
+internal class InventoryConfig : SyncedConfig2<InventoryConfig>
 {
+	private const string GUID_ = MyPluginInfo.PLUGIN_GUID + "." + nameof(InventoryConfig);
 	private const string SECTION = "Inventory";
 
 	public readonly ConfigEntry<int> MaxItemCount;
 	public readonly ConfigEntry<bool> ClearOnWipe;
 	public readonly ConfigEntry<float> RetrieveSpeed;
 
-	public InventoryConfig(ConfigFile cfg)
+	public InventoryConfig(ConfigFile cfg) : base(GUID_)
 	{
 		MaxItemCount = cfg.Bind(
 			new ConfigDefinition(SECTION, "MaxItemCount"),

--- a/src/ShipInventoryUpdated/Configurations/UnlockConfig.cs
+++ b/src/ShipInventoryUpdated/Configurations/UnlockConfig.cs
@@ -6,15 +6,16 @@ namespace ShipInventoryUpdated.Configurations;
 /// <summary>
 /// Class that holds the configurations related to the unlocking of the inventory
 /// </summary>
-internal class UnlockConfig
+internal class UnlockConfig : SyncedConfig2<UnlockConfig>
 {
+	private const string GUID_ = MyPluginInfo.PLUGIN_GUID + "." + nameof(UnlockConfig);
 	private const string SECTION = "Unlock";
 
 	public readonly ConfigEntry<string> UnlockName;
 	public readonly ConfigEntry<int> UnlockCost;
 	public readonly ConfigEntry<bool> IsChuteUnlocked;
 
-	public UnlockConfig(ConfigFile cfg)
+	public UnlockConfig(ConfigFile cfg) : base(GUID_)
 	{
 		UnlockName = cfg.Bind(
 			new ConfigDefinition(SECTION, "ChuteUnlockName"),

--- a/src/ShipInventoryUpdated/Configurations/UnlockConfig.cs
+++ b/src/ShipInventoryUpdated/Configurations/UnlockConfig.cs
@@ -1,4 +1,6 @@
 ﻿using BepInEx.Configuration;
+using CSync.Extensions;
+using CSync.Lib;
 using ShipInventoryUpdated.Helpers;
 
 namespace ShipInventoryUpdated.Configurations;
@@ -12,8 +14,8 @@ internal class UnlockConfig : SyncedConfig2<UnlockConfig>
 	private const string SECTION = "Unlock";
 
 	public readonly ConfigEntry<string> UnlockName;
-	public readonly ConfigEntry<int> UnlockCost;
-	public readonly ConfigEntry<bool> IsChuteUnlocked;
+	[SyncedEntryField] public readonly SyncedEntry<int> UnlockCost;
+	[SyncedEntryField] public readonly SyncedEntry<bool> IsChuteUnlocked;
 
 	public UnlockConfig(ConfigFile cfg) : base(GUID_)
 	{
@@ -23,19 +25,21 @@ internal class UnlockConfig : SyncedConfig2<UnlockConfig>
 			new ConfigDescription(Localization.Get("configuration.unlock.unlockName.description"))
 		);
 
-		UnlockCost = cfg.Bind(
+		UnlockCost = cfg.BindSyncedEntry(
 			new ConfigDefinition(SECTION, "ChuteUnlockCost"),
 			60,
 			new ConfigDescription(Localization.Get("configuration.unlock.unlockCost.description"))
 		);
 
-		IsChuteUnlocked = cfg.Bind(
+		IsChuteUnlocked = cfg.BindSyncedEntry(
 			new ConfigDefinition(SECTION, "ChuteIsUnlock"),
 			false,
 			new ConfigDescription(Localization.Get("configuration.unlock.isUnlockable.description"))
 		);
 
 		UnlockName.SettingChanged += (_, _) => Patches.Terminal_Patches.AssignNewCommand(UnlockName.Value);
-		UnlockCost.SettingChanged += (_, _) => Patches.Terminal_Patches.AssignNewCost(UnlockCost.Value);
+		UnlockCost.Changed += (_, _) => Patches.Terminal_Patches.AssignNewCost(UnlockCost.Value);
+		
+		ConfigManager.Register(this);
 	}
 }

--- a/src/ShipInventoryUpdated/Dependencies/LethalConfig/Dependency.cs
+++ b/src/ShipInventoryUpdated/Dependencies/LethalConfig/Dependency.cs
@@ -120,7 +120,7 @@ internal static class Dependency
 		));
 		
 		LethalConfigManager.AddConfigItem(new FloatInputFieldConfigItem(
-			config.RetrieveSpeed.Entry,
+			config.RetrieveSpeed,
 			new FloatInputFieldOptions
 			{
 				Name = Localization.Get("configuration.inventory.retrieveSpeed.name"),

--- a/src/ShipInventoryUpdated/Dependencies/LethalConfig/Dependency.cs
+++ b/src/ShipInventoryUpdated/Dependencies/LethalConfig/Dependency.cs
@@ -72,7 +72,7 @@ internal static class Dependency
 	private static void ApplyChuteConfiguration(ChuteConfig config)
 	{
 		LethalConfigManager.AddConfigItem(new TextInputFieldConfigItem(
-			config.Blacklist,
+			config.Blacklist.Entry,
 			new TextInputFieldOptions
 			{
 				Name = Localization.Get("configuration.chute.blacklist.name"),
@@ -83,7 +83,7 @@ internal static class Dependency
 		));
 		
 		LethalConfigManager.AddConfigItem(new FloatInputFieldConfigItem(
-			config.StoreSpeed,
+			config.StoreSpeed.Entry,
 			new FloatInputFieldOptions
 			{
 				Name = Localization.Get("configuration.chute.storeSpeed.name"),
@@ -100,7 +100,7 @@ internal static class Dependency
 	private static void ApplyInventoryConfiguration(InventoryConfig config)
 	{
 		LethalConfigManager.AddConfigItem(new IntInputFieldConfigItem(
-			config.MaxItemCount,
+			config.MaxItemCount.Entry,
 			new IntInputFieldOptions
 			{
 				Name = Localization.Get("configuration.inventory.maxItemCount.name"),
@@ -111,7 +111,7 @@ internal static class Dependency
 		));
 		
 		LethalConfigManager.AddConfigItem(new BoolCheckBoxConfigItem(
-			config.ClearOnWipe,
+			config.ClearOnWipe.Entry,
 			new BoolCheckBoxOptions
 			{
 				Name = Localization.Get("configuration.inventory.clearOnWipe.name"),
@@ -120,7 +120,7 @@ internal static class Dependency
 		));
 		
 		LethalConfigManager.AddConfigItem(new FloatInputFieldConfigItem(
-			config.RetrieveSpeed,
+			config.RetrieveSpeed.Entry,
 			new FloatInputFieldOptions
 			{
 				Name = Localization.Get("configuration.inventory.retrieveSpeed.name"),
@@ -167,7 +167,7 @@ internal static class Dependency
 		));
 
 		LethalConfigManager.AddConfigItem(new IntInputFieldConfigItem(
-			config.UnlockCost,
+			config.UnlockCost.Entry,
 			new IntInputFieldOptions
 			{
 				Name = Localization.Get("configuration.unlock.unlockCost.name"),
@@ -178,7 +178,7 @@ internal static class Dependency
 		));
 
 		LethalConfigManager.AddConfigItem(new BoolCheckBoxConfigItem(
-			config.IsChuteUnlocked,
+			config.IsChuteUnlocked.Entry,
 			new BoolCheckBoxOptions
 			{
 				Name = Localization.Get("configuration.unlock.isUnlockable.name"),

--- a/src/ShipInventoryUpdated/Dependencies/LethalConfig/Dependency.cs
+++ b/src/ShipInventoryUpdated/Dependencies/LethalConfig/Dependency.cs
@@ -83,7 +83,7 @@ internal static class Dependency
 		));
 		
 		LethalConfigManager.AddConfigItem(new FloatInputFieldConfigItem(
-			config.StoreSpeed.Entry,
+			config.StoreSpeed,
 			new FloatInputFieldOptions
 			{
 				Name = Localization.Get("configuration.chute.storeSpeed.name"),

--- a/src/ShipInventoryUpdated/ShipInventoryUpdated.cs
+++ b/src/ShipInventoryUpdated/ShipInventoryUpdated.cs
@@ -11,6 +11,7 @@ namespace ShipInventoryUpdated;
 // Hard
 [BepInDependency("WhiteSpike.InteractiveTerminalAPI", "1.3.0")]
 [BepInDependency(LethalLib.Plugin.ModGUID)]
+[BepInDependency("com.sigurd.csync", "5.0.1")] 
 // Soft
 [BepInDependency(LethalConfig.PluginInfo.Guid, BepInDependency.DependencyFlags.SoftDependency)]
 public class ShipInventoryUpdated : BaseUnityPlugin

--- a/src/ShipInventoryUpdated/ShipInventoryUpdated.csproj
+++ b/src/ShipInventoryUpdated/ShipInventoryUpdated.csproj
@@ -22,6 +22,7 @@
       PrivateAssets="all" />
     <PackageReference Include="LethalCompany.GameLibs.Steam" Version="*-*" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Sigurd.BepInEx.CSync" Version="5.0.1" />
     <PackageReference Include="UnityEngine.Modules" Version="2022.3.9" IncludeAssets="compile"
       PrivateAssets="all" />
     <PackageReference Include="MinVer" Version="6.*" PrivateAssets="all" />


### PR DESCRIPTION
Added synchronization of certain configs:
- `ChuteBlacklist`
- `MaxItemCount`
- `ClearOnWipe`
- `ChuteUnlockCost`
- `ChuteIsUnlock`

Due to how the configurations are made, it is not possible to visually sync configs using LethalConfig. The configs do get updated, but they don't visually get updated. 